### PR TITLE
Have download link load the raw version of the PDF

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ That's why I decided to start this cookbook with all the topics you need to look
 It's not only useful for beginners, professionals will definitely like the case study section.
 
 Here's the **download** shortcut: \
-[Data Engineering Cookbook PDF](https://github.com/andkret/Cookbook/blob/master/Data%20Engineering%20Cookbook.pdf)
+[Data Engineering Cookbook PDF](https://github.com/andkret/Cookbook/raw/master/Data%20Engineering%20Cookbook.pdf)
 
 ## How to use the cookbook
 I split this cookbook into five parts


### PR DESCRIPTION
Currently the "Here's the download shortcut:" link loads the PDF within the GitHub UI. It does not download the PDF. This is a bit of a pain as the PDF is 3 MB (takes a while to load inline) and 124 pages (can't navigate that well when the PDF is loaded inline). 

This just points to the raw PDF file, which will download the file as an attachment.