### PR TITLE
fixed graphics location

### DIFF
--- a/Data Engineering Cookbook.tex
+++ b/Data Engineering Cookbook.tex
@@ -151,7 +151,7 @@ Model outputs are very abstract. You also need to post-process the model outputs
 
 \begin{figure}[htbp]
   \centering
-     \includegraphics[width=0.9\textwidth]{images/Machine-Learning-Pipeline}
+     \includegraphics[width=0.9\textwidth]{images/Machine-Learning-Pipeline.png}
   \caption{The Machine Learning Pipeline}
   \label{fig:Bild1}
 \end{figure}
@@ -597,7 +597,7 @@ A typical old-school platform deployment would look like the picture below. Devi
 
 \begin{figure}[htbp]
   \centering
-     \includegraphics[width=0.7\textwidth]{images/Common-SQL-Architecture}
+     \includegraphics[width=0.7\textwidth]{images/Common-SQL-Architecture.png}
   \caption{Common SQL Platform Architecture}
   \label{fig:Bild1}
 \end{figure}
@@ -626,7 +626,7 @@ Scaling up the system is fairly easy.
 
 \begin{figure}[htbp]
   \centering
-     \includegraphics[width=0.7\textwidth]{images/SQL-Scaling-UP}
+     \includegraphics[width=0.7\textwidth]{images/SQL-Scaling-UP.png}
   \caption{Scaling up a SQL Database}
   \label{fig:Bild1}
 \end{figure}
@@ -642,7 +642,7 @@ The simplest way of scaling out an SQL database is using a storage area network 
 
 \begin{figure}[htbp]
   \centering
-     \includegraphics[width=0.7\textwidth]{images/SQL-Scaling-Out}
+     \includegraphics[width=0.7\textwidth]{images/SQL-Scaling-Out.png}
   \caption{Scaling out a SQL Database}
   \label{fig:Bild1}
 \end{figure}
@@ -787,7 +787,7 @@ Data comes in and gets stored, analytics loads the data from storage and creates
 
 \begin{figure}[htbp]
   \centering
-     \includegraphics[width=0.9\textwidth]{images/Simple-Batch-Processing-Workflow}
+     \includegraphics[width=0.9\textwidth]{images/Simple-Batch-Processing-Workflow.png}
   \caption{Batch Processing Pipeline}
   \label{fig:Bild1}
 \end{figure}
@@ -818,7 +818,7 @@ As a result the scope of the produced insight is also limited. Because the big p
 
 \begin{figure}[htbp]
   \centering
-     \includegraphics[width=0.9\textwidth]{images/Simple-Stream-Processing-Workflow}
+     \includegraphics[width=0.9\textwidth]{images/Simple-Stream-Processing-Workflow.png}
   \caption{Stream Processing Pipeline}
   \label{fig:Bild1}
 \end{figure}
@@ -1217,7 +1217,7 @@ It will not only store your file, Hadoop will also replicate it two or three tim
 
 \begin{figure}[htbp]
   \centering
-     \includegraphics[width=0.9\textwidth]{images/HDFS-Master-DataNodes}
+     \includegraphics[width=0.9\textwidth]{images/HDFS-Master-DataNodes.png}
   \caption{HDFS Master and Data Nodes}
   \label{fig:Bild1}
 \end{figure}
@@ -1234,7 +1234,7 @@ These blocks are then distributed and replicated on the Hadoop cluster. The spli
 
 \begin{figure}[htbp]
   \centering
-     \includegraphics[width=0.9\textwidth]{images/HDFS-Distributed-FileSystem}
+     \includegraphics[width=0.9\textwidth]{images/HDFS-Distributed-FileSystem.png}
   \caption{Distribution of Blocks for a 512MB File}
   \label{fig:Bild1}
 \end{figure}
@@ -1495,7 +1495,7 @@ Here's an example how such a map and reduce process works with data:
 
 \begin{figure}[htbp]
   \centering
-     \includegraphics[width=0.9\textwidth]{images/MapReduce-Process-Detailed}
+     \includegraphics[width=0.9\textwidth]{images/MapReduce-Process-Detailed.png}
   \caption{Mapping of input files and reducing of mapped records}
   \label{fig:Bild1}
 \end{figure}
@@ -1545,7 +1545,7 @@ Every reducer input record then has a list of values and you can calculate (1+5+
 
 \begin{figure}[htbp]
   \centering
-     \includegraphics[width=0.9\textwidth]{images/MapReduce-Time-Series-example}
+     \includegraphics[width=0.9\textwidth]{images/MapReduce-Time-Series-example.png}
   \caption{MapReduce Example of Time Series Data}
   \label{fig:Bild1}
 \end{figure}
@@ -1565,7 +1565,7 @@ MapReduce is awesome for simpler analytics tasks, like counting stuff. It just h
 
 \begin{figure}[htbp]
   \centering
-     \includegraphics[width=0.9\textwidth]{images/MapReduce-Process}
+     \includegraphics[width=0.9\textwidth]{images/MapReduce-Process.png}
   \caption{The Map Reduce Process}
   \label{fig:Bild1}
 \end{figure}
@@ -1607,7 +1607,7 @@ There are some very misleading articles out there titled Spark or Hadoop, Spark 
 
 \begin{figure}[htbp]
   \centering
-     \includegraphics[width=0.9\textwidth]{images/Table-Hadoop-and-Spark}
+     \includegraphics[width=0.9\textwidth]{images/Table-Hadoop-and-Spark.png}
   \caption{Hadoop vs Spark capabilities}
   \label{fig:Bild1}
 \end{figure}
@@ -1685,7 +1685,7 @@ Spark can then natively identify on what data node the needed data is stored. Th
 
 \begin{figure}[htbp]
   \centering
-     \includegraphics[width=0.9\textwidth]{images/Spark-Data-Locality}
+     \includegraphics[width=0.9\textwidth]{images/Spark-Data-Locality.png}
   \caption{Spark Using Hadoop Data Locality}
   \label{fig:Bild1}
 \end{figure}
@@ -1724,7 +1724,7 @@ Having a single resource manager instead of two independent ones makes it a lot 
 
 \begin{figure}[htbp]
   \centering
-     \includegraphics[width=0.9\textwidth]{images/Spark-Yarn}
+     \includegraphics[width=0.9\textwidth]{images/Spark-Yarn.png}
   \caption{Spark Resource Management With YARN}
   \label{fig:Bild1}
 \end{figure}
@@ -2321,7 +2321,7 @@ The key components were Chuckwa, a scalable data collection system, Amazon S3 an
 
 \begin{figure}[htbp]
   \centering
-     \includegraphics[width=0.9\textwidth]{images/Netflix-Chuckwa-Pipeline}
+     \includegraphics[width=0.9\textwidth]{images/Netflix-Chuckwa-Pipeline.png}
   \caption{Old Netflix Batch Processing Pipeline}
   \label{fig:Bild1}
 \end{figure}
@@ -2369,7 +2369,7 @@ What is currently being watched is only a part of the data that is used to gener
 
 \begin{figure}[htbp]
   \centering
-     \includegraphics[width=0.9\textwidth]{images/Netflix-Trending-Now-Screenshot}
+     \includegraphics[width=0.9\textwidth]{images/Netflix-Trending-Now-Screenshot.png}
   \caption{Netflix Trending Now Feature}
   \label{fig:Bild1}
 \end{figure}
@@ -2399,7 +2399,7 @@ After the analytics the workflow is straight forward. The trending data is store
 
 \begin{figure}[htbp]
   \centering
-     \includegraphics[width=0.9\textwidth]{images/Netflix-Streaming-Pipeline}
+     \includegraphics[width=0.9\textwidth]{images/Netflix-Streaming-Pipeline.png}
   \caption{Netflix Streaming Pipeline}
   \label{fig:Bild1}
 \end{figure}


### PR DESCRIPTION
added extensions to images

During conversion from text to epub (using pandoc) i found that images are not included because 'includegraphics' image location didn't include file extension