### PR TITLE
Fix links to sections in updates

### DIFF
--- a/sections/10-Updates.md
+++ b/sections/10-Updates.md
@@ -5,19 +5,19 @@ What's new? Here you can find a list of all the updates with links to the sectio
 
 - **2024-03-01**
   - Added updates section
-  - Reworked the Hands-on courses section with 5 free courses / tutorials from Andreas on YouTube [click here](sections/04-HandsOnCourse.md)
+  - Reworked the Hands-on courses section with 5 free courses / tutorials from Andreas on YouTube [click here](04-HandsOnCourse.md)
 
 
 - **2024-02-28**
-  - Added Data Engineering Roadmap for Data Scientists: [click here](sections/01-Introduction.md#roadmap-for-data-scientists)
+  - Added Data Engineering Roadmap for Data Scientists: [click here](01-Introduction.md#roadmap-for-data-scientists)
 
 
 - **2024-02-25**
-  - Data Engineering Roadmap for Software Engineers: [click here](sections/01-Introduction.md#roadmap-for-software-engineers)
+  - Data Engineering Roadmap for Software Engineers: [click here](01-Introduction.md#roadmap-for-software-engineers)
 
 
 - **2024-02-20**
-  - Data Engineering Roadmap for Data Analysts: [click here](sections/01-Introduction.md#roadmap-for-data-analysts)
+  - Data Engineering Roadmap for Data Analysts: [click here](01-Introduction.md#roadmap-for-data-analysts)
 
 
 <!---


### PR DESCRIPTION
I was appreciating the new updates section and noticed the links needed the `sections` directory removing.