### PR TITLE
docs: fix implementation spelling in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Find the change log with all recent updates here: [SEE UPDATES](sections/10-Upda
 - [Connect](sections/03-AdvancedSkills.md#connect)
   - [REST APIs](sections/03-AdvancedSkills.md#rest-apis)
     - [API Design](sections/03-AdvancedSkills.md#api-design)
-    - [Implemenation Frameworks](sections/03-AdvancedSkills.md#implementation-frameworks)
+    - [Implementation Frameworks](sections/03-AdvancedSkills.md#implementation-frameworks)
     - [Security](sections/03-AdvancedSkills.md#security)
   - [Apache Nifi](sections/03-AdvancedSkills.md#apache-nifi)
   - [Logstash](sections/03-AdvancedSkills.md#logstash)


### PR DESCRIPTION
Changes:
- `Implemenation Frameworks` -> `Implementation Frameworks` in `README.md` (1 occurrence(s))

Verification:
- Applied exact text replacements against the current upstream base branch.
- Checked the repository is not archived or a fork.
- Checked for open PRs matching the typo term before opening this PR.
